### PR TITLE
Fix download_url for windows agent installation

### DIFF
--- a/recipes/agent_windows.rb
+++ b/recipes/agent_windows.rb
@@ -9,7 +9,7 @@ opts << "/D=#{install_path}" if node['go']['agent']['install_path']
 download_url = node['go']['agent']['download_url']
 if !download_url
   major_ver = node['go']['version'].split('-', 2).first
-  download_url = "http://download01.thoughtworks.com/go/#{major_ver}/ga/go-agent-#{node['go']['version']}-setup.exe"
+  download_url = "http://download.go.cd/gocd/go-agent-#{node['go']['version']}-setup.exe"
 end
 
 windows_package 'Go Agent' do


### PR DESCRIPTION
The download URL for the windows agent installer is using a different URL pattern than is currently
in use on the thoughtworks website. This change updates to use the current pattern. The URL for the
server install seems to be fine.